### PR TITLE
chore: add archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # 🚨 Archived: Remix → React Router Transition
 
-With the introduction of React Router v7, the Remix team has announced that the official upgrade path for existing Remix applications is to move to React Router v7, as described in their [announcement](https://remix.run/blog/react-router-v7).
+With the introduction of React Router v7, the Remix team has announced that the
+official upgrade path for existing Remix applications is to move to React Router
+v7, as described in their
+[announcement](https://remix.run/blog/react-router-v7).
 
-This example application has been **archived** and is no longer being updated. However, **we continue to fully support and maintain the `@arcjet/remix` framework adapter**: [`@arcjet/remix` on npm](https://www.npmjs.com/package/@arcjet/remix).
+This example application has been **archived** and is no longer being updated.
+However, **we continue to fully support and maintain the [Remix
+SDK (`@arcjet/remix`)](https://www.npmjs.com/package/@arcjet/remix)**.
 
-For an up-to-date reference implementation that follows the new recommended direction, please see our **React Router example application**: [arcjet/example-react-router](https://github.com/arcjet/example-react-router).
-
+For an up-to-date reference implementation that follows the new recommended
+direction, please see our [**React Router
+example**](https://github.com/arcjet/example-react-router).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
+# 🚨 Archived: Remix → React Router Transition
+
+With the introduction of React Router v7, the Remix team has announced that the official upgrade path for existing Remix applications is to move to React Router v7, as described in their [announcement](https://remix.run/blog/react-router-v7).
+
+This example application has been **archived** and is no longer being updated. However, **we continue to fully support and maintain the `@arcjet/remix` framework adapter**: [`@arcjet/remix` on npm](https://www.npmjs.com/package/@arcjet/remix).
+
+For an up-to-date reference implementation that follows the new recommended direction, please see our **React Router example application**: [arcjet/example-react-router](https://github.com/arcjet/example-react-router).
+
+
+---
+
 <a href="https://arcjet.com" target="_arcjet-home">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://arcjet.com/logo/arcjet-dark-lockup-voyage-horizontal.svg">
     <img src="https://arcjet.com/logo/arcjet-light-lockup-voyage-horizontal.svg" alt="Arcjet Logo" height="128" width="auto">
   </picture>
 </a>
-
-> [!IMPORTANT]
->
-> [Remix is now React Router v7](https://remix.run/blog/incremental-path-to-react-19).
 
 # Arcjet Remix example app
 


### PR DESCRIPTION
I think it's time to wave goodbye to `remix@2` - at least as far as our example apps go. We now have first-class react-router support we can direct users to.

This example app is outdated and `remix@2` seems to only be receiving minimal updates. It would require a fair amount of work to modernize and port into the `examples` monorepo.

@davidmytton if you agree, I'll ask you to archive the repo after this gets merged but happy to have more of a discussion!